### PR TITLE
utf8_encode() responses without explicit encoding

### DIFF
--- a/src/Parsers/XML.php
+++ b/src/Parsers/XML.php
@@ -11,6 +11,17 @@ class XML
             $string = $string->getBody()->__toString();
         }
 
-        return new \SimpleXMLElement((string) $string);
+        $string = (string)$string;
+
+        if (!preg_match('/^<\?xml[^>]+?encoding=".+"\?>/', $string)) {
+            if (
+                mb_detect_encoding($string) !== 'UTF-8' ||
+                !mb_check_encoding($string, 'UTF-8')
+            ) {
+                $string = utf8_encode($string);
+            }
+        }
+
+        return new \SimpleXMLElement($string);
     }
 }


### PR DESCRIPTION
If there's no explicit encoding on the response, encode it as utf-8