### PR TITLE
HOTFIX | Add missing range of hex-encoded ASCII control characters

### DIFF
--- a/src/Parsers/XML.php
+++ b/src/Parsers/XML.php
@@ -9,13 +9,13 @@ class XML
      * Matches xml-encoded character references (decimal or hex) for ASCII control characters group.
      * Will match any string that begins with &# and ends with ; and in between is either
      * (0?[0-9]|[12][0-9]|3[01]) - a decimal integer between 00 and 31 (leading 0 optional)
-     * ([xX]((0?[0-9A-Fa-f])|(1[0-9A-Fa-f]))) - a hex integer between 00 and 1F (upper or lower case, leading 0 optional)
+     * ([xX](0?|1)[0-9A-Fa-f]) - a hex integer between 00 and 1F (upper or lower case, leading 0 optional)
      *
      * @link https://regexr.com/5c41j
      * @link https://en.wikipedia.org/wiki/ASCII#Control_characters
      * @link https://www.liquid-technologies.com/XML/CharRefs.aspx
      */
-    const REGEX_ASCII_CONTROL_CHARACTERS = '/(&#((0?[0-9]|[12][0-9]|3[01])|([xX]((0?[0-9A-Fa-f])|(1[0-9A-Fa-f]))));)/';
+    const REGEX_ASCII_CONTROL_CHARACTERS = '/(&#((0?[0-9]|[12][0-9]|3[01])|([xX](0?|1)[0-9A-Fa-f]));)/';
 
     public function parse($string)
     {

--- a/src/Parsers/XML.php
+++ b/src/Parsers/XML.php
@@ -9,13 +9,13 @@ class XML
      * Matches xml-encoded character references (decimal or hex) for ASCII control characters group.
      * Will match any string that begins with &# and ends with ; and in between is either
      * (0?[0-9]|[12][0-9]|3[01]) - a decimal integer between 00 and 31 (leading 0 optional)
-     * ([xX](0?[0-9]|1[0-9A-Fa-f]))) - a hex integer between 00 and 1F (leading 0 optional, can be upper or lower case)
+     * ([xX]((0?[0-9A-Fa-f])|(1[0-9A-Fa-f]))) - a hex integer between 00 and 1F (upper or lower case, leading 0 optional)
      *
-     * @link https://regexr.com/5be0p
+     * @link https://regexr.com/5c41j
      * @link https://en.wikipedia.org/wiki/ASCII#Control_characters
      * @link https://www.liquid-technologies.com/XML/CharRefs.aspx
      */
-    const REGEX_ASCII_CONTROL_CHARACTERS = '/(&#((0?[0-9]|[12][0-9]|3[01])|([xX](0?[0-9]|1[0-9A-Fa-f])));)/';
+    const REGEX_ASCII_CONTROL_CHARACTERS = '/(&#((0?[0-9]|[12][0-9]|3[01])|([xX]((0?[0-9A-Fa-f])|(1[0-9A-Fa-f]))));)/';
 
     public function parse($string)
     {


### PR DESCRIPTION
- Previous version didn't include 0xA through 0xE.
- Added some extra parens on the hex side of the regex to clarify groupings around the | (not strictly necessary)
- Updated regexr link